### PR TITLE
Comment out width: 100vh in main.scss

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ To build:
 
 To view locally:
  1. Run `npm install -g node-static`
- 2. Run `static out`
+ 2. Run `static dest`
  3. Point your web browser at [http://localhost:8080](http://localhost:8080)

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -27,7 +27,7 @@ body{
   display: flex;
   flex-direction: column;
   width: 100vw;
-  height: 100vh;
+  //height: 100vh;
 }
 
 


### PR DESCRIPTION
This change fixes an issue with the footer not rendering at bottom of page in Safari on Mac desktop. The change does not effect Chrome or Firefox on Mac desktop. I have not checked the rendering on any mobile device or any version of IE.
