### PR TITLE
Change server instruction in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ To build:
 
 To view locally:
  1. Run `npm install -g node-static`
- 2. Run `static out`
+ 2. Run `static dest`
  3. Point your web browser at [http://localhost:8080](http://localhost:8080)


### PR DESCRIPTION
It took me a while to figure out that I needed to specify the destination folder when using `static` to serve locally, so I made it explicit in the README.
