### PR TITLE
Safari desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ To build:
 
 To view locally:
  1. Run `npm install -g node-static`
- 2. Run `static out`
+ 2. Run `static dest`
  3. Point your web browser at [http://localhost:8080](http://localhost:8080)

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -27,7 +27,7 @@ body{
   display: flex;
   flex-direction: column;
   width: 100vw;
-  height: 100vh;
+  //height: 100vh;
 }
 
 


### PR DESCRIPTION
This change fixes an issue with the footer not rendering at the bottom of the page in Safari on Mac desktop. It does not effect Chrome or Firefox on Mac desktop. I haven't checked the result in IE or on any mobile device.
